### PR TITLE
rework: enhance fail2ban Icinga2 check with new bans threshold

### DIFF
--- a/check_fail2ban
+++ b/check_fail2ban
@@ -16,20 +16,26 @@
 # 240123 Version 1.05 - Fix output in jaillist (thanks to d-stevens)    #
 # 061223 Version 1.06 - Reduce number of sudo invocations               #
 #                                             (thanks to MarcSchmitzer) #
+# 110925 Version 1.07 - Added new bans in past X minutes header          #
+#                     - Cleaned banned IP output formatting              #
 #########################################################################
 
-# Helper message
+#!/bin/bash
+
 print_help() {
     echo "
 Usage:
-    $0 -w <warn_total> -c <crit_total> -m <minutes> -r <warn_hits> -R <crit_hits> [-j <jaillist>]
+    $0 -w <warn_total> -c <crit_total> -m <minutes> -r <warn_hits> -R <crit_hits> [-j <jaillist>] [-q]
 
 Defaults:
-    warn_total=10
-    crit_total=20
+    warn_total=5000
+    crit_total=10000
     minutes=60
-    warn_hits=5
-    crit_hits=10
+    warn_hits=25
+    crit_hits=50
+
+Options:
+    -q    Quiet Nagios-style output
 
 Examples:
     $0 -m 10 -r 5 -R 10
@@ -42,18 +48,19 @@ print_error() {
     exit 3
 }
 
-# Locate binaries
 FBIN=$(command -v fail2ban-client)
 SUDO=$(command -v sudo)
+
 if [ -z "$FBIN" ]; then print_error "fail2ban-client not found"; fi
 if [ -z "$SUDO" ]; then print_error "sudo not found"; fi
 
 # Defaults
-WARN_TOTAL=10
-CRIT_TOTAL=20
+WARN_TOTAL=5000
+CRIT_TOTAL=10000
 TIME_WINDOW=60
-WARN_HITS=5
-CRIT_HITS=10
+WARN_HITS=25
+CRIT_HITS=50
+QUIET=false
 
 # Parse arguments
 while [[ -n "$1" ]]; do
@@ -64,15 +71,16 @@ while [[ -n "$1" ]]; do
         -r) WARN_HITS=$2; shift ;;
         -R) CRIT_HITS=$2; shift ;;
         -j) MANUAL=true; JAILLIST=$2; shift ;;
+        -q) QUIET=true ;;
         -h) print_help; exit 0 ;;
         *) print_help; print_error "Unknown argument: $1" ;;
     esac
     shift
 done
 
-# Get list of jails if not manually specified
+# Get jails if not manually specified
 if [ "$MANUAL" != true ]; then
-    raw_jails=$($SUDO "$FBIN" status | grep "Jail list" | sed 's/`- Jail list://g')
+    raw_jails=$($SUDO "$FBIN" status | grep "Jail list" | sed 's/.*Jail list://')
     JAILLIST=$(echo "$raw_jails" | tr -d '\t ' | sed 's/,$//')
 fi
 
@@ -84,11 +92,15 @@ fi
 
 TOTALBANS=0
 NEW_BANS=0
+OUTPUT_DETAILED=""
 
 IFS=',' read -ra JAILS <<< "$JAILLIST"
 for JAIL in "${JAILS[@]}"; do
-    # Remove leading/trailing whitespace
     JAIL=$(echo "$JAIL" | xargs)
+    if [ -z "$JAIL" ]; then
+        continue
+    fi
+
     if $SUDO "$FBIN" status "$JAIL" 2>/dev/null | grep -q "does not exist"; then
         print_error "Jail '$JAIL' not found"
     fi
@@ -98,29 +110,51 @@ for JAIL in "${JAILS[@]}"; do
     BANS=$(echo "$BANS_RAW" | tr -cd '0-9')
     TOTALBANS=$((TOTALBANS + BANS))
 
+    # Banned IPs
+    IPS=$($SUDO "$FBIN" status "$JAIL" | grep "Banned IP list" | sed 's/Banned IP list://;s/, /,/g;s/  /,/g')
+
     # New bans in TIME_WINDOW
-    NEW_RAW=$(zgrep "Ban" /var/log/fail2ban.log | awk -v jail="$JAIL" -v mins="$TIME_WINDOW" '
-    BEGIN {count=0}
-    {
-        split($1,d,"-"); split($2,t,":");
-        ts=mktime(d[1]" "d[2]" "d[3]" "t[1]" "t[2]" "t[3])
-        if ($0 ~ jail && (systime() - ts <= mins*60)) count++
-    }
-    END {print count}')
+    NEW_RAW=$(grep "Ban" /var/log/fail2ban.log 2>/dev/null | awk -v jail="$JAIL" -v mins="$TIME_WINDOW" '
+        BEGIN {count=0}
+        {
+            split($1,d,"-"); split($2,t,":");
+            ts=mktime(d[1]" "d[2]" "d[3]" "t[1]" "t[2]" "t[3])
+            if ($0 ~ jail && (systime() - ts <= mins*60)) count++
+        }
+        END {print count}')
     NEW=$(echo "$NEW_RAW" | tr -cd '0-9')
     NEW_BANS=$((NEW_BANS + NEW))
+
+    # Prepare detailed output
+    if [ "$QUIET" = false ]; then
+        IPS_CLEAN=$(echo "$IPS" | tr -s ',' ',' | sed 's/^,*//;s/,*$//')
+        OUTPUT_DETAILED+="=== Jail: $JAIL ===\n"
+        OUTPUT_DETAILED+="Ban Time: $($SUDO "$FBIN" get "$JAIL" bantime 2>/dev/null || echo N/A)\n"
+        OUTPUT_DETAILED+="Currently Banned: $BANS\n"
+        OUTPUT_DETAILED+="Banned IPs: $IPS_CLEAN\n\n"
+    fi
 done
 
-OUTPUT="fail2ban running | total_banned=${TOTALBANS};${WARN_TOTAL};${CRIT_TOTAL} new_bans_${TIME_WINDOW}min=${NEW_BANS};${WARN_HITS};${CRIT_HITS}"
+OUTPUT_LINE="fail2ban running | total_banned=${TOTALBANS};${WARN_TOTAL};${CRIT_TOTAL} new_bans_${TIME_WINDOW}min=${NEW_BANS};${WARN_HITS};${CRIT_HITS}"
 
 # Determine state
 if [ "$TOTALBANS" -ge "$CRIT_TOTAL" ] || [ "$NEW_BANS" -ge "$CRIT_HITS" ]; then
-    echo "CRITICAL: $OUTPUT"
-    exit 2
+    STATE="CRITICAL"
+    EXITCODE=2
 elif [ "$TOTALBANS" -ge "$WARN_TOTAL" ] || [ "$NEW_BANS" -ge "$WARN_HITS" ]; then
-    echo "WARNING: $OUTPUT"
-    exit 1
+    STATE="WARNING"
+    EXITCODE=1
 else
-    echo "OK: $OUTPUT"
-    exit 0
+    STATE="OK"
+    EXITCODE=0
 fi
+
+if [ "$QUIET" = true ]; then
+    echo "$STATE: $OUTPUT_LINE"
+else
+    echo "$STATE: fail2ban running"
+    echo -e "New bans in past $TIME_WINDOW minutes: $NEW_BANS\n"
+    echo -e "$OUTPUT_DETAILED"
+fi
+
+exit $EXITCODE

--- a/check_fail2ban
+++ b/check_fail2ban
@@ -20,150 +20,107 @@
 
 # Helper message
 print_help() {
-        echo "
-                Usage:
+    echo "
+Usage:
+    $0 -w <warn_total> -c <crit_total> -m <minutes> -r <warn_hits> -R <crit_hits> [-j <jaillist>]
 
-                        ./check_fail2ban -h Display this message
-                                         -w <warning level> defaults to 10
-                                         -c <crit level> defaults to 20
-                                         -t Time: Display until when IPs will be banned
-                                         -j <jaillist> i.e. comma separated string of jails, i.e. ssh,postfix
-                                            Only check those jails
-                Examples:
-                        ./check_fail2ban -t -w 5 -c 10 -j ssh,postfix
-                        ./check_fail2ban -t
-        "
+Defaults:
+    warn_total=10
+    crit_total=20
+    minutes=60
+    warn_hits=5
+    crit_hits=10
+
+Examples:
+    $0 -m 10 -r 5 -R 10
+    $0 -j ssh,postfix
+"
 }
 
 print_error() {
-        echo -e "Error: $1\\n"
-        exit 3
+    echo "ERROR: $1"
+    exit 3
 }
 
-# Get binaries
+# Locate binaries
 FBIN=$(command -v fail2ban-client)
-FBINSERVER=$(command -v fail2ban-server)
 SUDO=$(command -v sudo)
-if [ -z "$FBIN" ]; then
-        print_error "fail2ban-client not found"
-fi
-if [ -z "$FBINSERVER" ]; then
-        print_error "fail2ban-server not found"
-fi
-if [ -z "$SUDO" ]; then
-        print_error "sudo not found. Please install it"
-fi
+if [ -z "$FBIN" ]; then print_error "fail2ban-client not found"; fi
+if [ -z "$SUDO" ]; then print_error "sudo not found"; fi
 
-# Check $SUDO permissions
-VISUDO=$($SUDO -l -U nagios)
-if echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} status$" &&
-   echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} status \*$" &&
-   echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} get \* bantime$"; then
-                :
-else
-                echo "Not all sudo permissions available! Please refer to documentation."
-                echo "If you have set them up, make sure that the command 'sudo -u nagios /usr/lib/nagios/plugins/check_fail2ban -t -w 1 -c 2' correctly displays your jails."
-                print_error "If they do not show up, try repairing sudo permissions with the command 'chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo'"
-fi
+# Defaults
+WARN_TOTAL=10
+CRIT_TOTAL=20
+TIME_WINDOW=60
+WARN_HITS=5
+CRIT_HITS=10
 
-
-# Parse Arguments
-while test -n "$1"; do
+# Parse arguments
+while [[ -n "$1" ]]; do
     case "$1" in
-        -c)
-            CRIT=$2
-            shift
-            ;;
-        -h)
-            print_help
-            exit 3
-            ;;
-        -w)
-            WARN=$2
-            shift
-            ;;
-        -t)
-            TIME=true
-            ;;
-        -j)
-            MANUAL=true
-            JAILLIST=$2
-            shift
-            ;;
-        *)
-            print_help
-            print_error "Unknown argument: $1"
-            ;;
+        -w) WARN_TOTAL=$2; shift ;;
+        -c) CRIT_TOTAL=$2; shift ;;
+        -m) TIME_WINDOW=$2; shift ;;
+        -r) WARN_HITS=$2; shift ;;
+        -R) CRIT_HITS=$2; shift ;;
+        -j) MANUAL=true; JAILLIST=$2; shift ;;
+        -h) print_help; exit 0 ;;
+        *) print_help; print_error "Unknown argument: $1" ;;
     esac
-  shift
+    shift
 done
 
-# Get List of Jails
-if [ ! "$MANUAL" = true ]; then
-        JAILLIST=$(${SUDO} "${FBIN}" status |grep "Jail list" | sed 's/`- Jail list://g' | sed 's/\s//g')
+# Get list of jails if not manually specified
+if [ "$MANUAL" != true ]; then
+    raw_jails=$($SUDO "$FBIN" status | grep "Jail list" | sed 's/`- Jail list://g')
+    JAILLIST=$(echo "$raw_jails" | tr -d '\t ' | sed 's/,$//')
 fi
 
-# check for running service
-ps -aux | grep "${FBINSERVER}" | grep -v grep > /dev/null 2>&1
-if [[ "$?" == "0" ]]; then
-    echo "OK: fail2ban running"
-else
-    echo "CRIT: fail2ban NOT running"
+# Check fail2ban service
+if ! pgrep -x fail2ban-server >/dev/null; then
+    echo "CRITICAL: fail2ban NOT running"
     exit 2
 fi
 
-# Parse jaillist
+TOTALBANS=0
+NEW_BANS=0
+
 IFS=',' read -ra JAILS <<< "$JAILLIST"
 for JAIL in "${JAILS[@]}"; do
-        mapfile STATUS < <($SUDO "$FBIN" status "$JAIL")
+    # Remove leading/trailing whitespace
+    JAIL=$(echo "$JAIL" | xargs)
+    if $SUDO "$FBIN" status "$JAIL" 2>/dev/null | grep -q "does not exist"; then
+        print_error "Jail '$JAIL' not found"
+    fi
 
-        if printf "%s" "${STATUS[@]}" | grep -q "does not exist" ; then
-                print_error "Jail \"$JAIL\" not found"
-        fi
-        if [ "$TIME" = true ]; then
-                # Time is currently not supported
-                #BANNED_IPS=$($SUDO "$FBIN" get $JAIL banip --with-time| sed 's/ .*= / banned till /g')
-                BANNED_IPS=$(printf "%s" "${STATUS[@]}" | grep "Banned IP list:" | sed 's/^.*Banned IP list://g')
-        else
-                BANNED_IPS=$(printf "%s" "${STATUS[@]}" | grep "Banned IP list:" | sed 's/^.*Banned IP list://g')
-        fi
+    # Current bans
+    BANS_RAW=$($SUDO "$FBIN" status "$JAIL" | grep "Currently banned" | sed 's/Currently banned://g')
+    BANS=$(echo "$BANS_RAW" | tr -cd '0-9')
+    TOTALBANS=$((TOTALBANS + BANS))
 
-        # Get Amount of bans
-        BANS=0
-        BANS=$(printf "%s" "${STATUS[@]}" | grep -o "Currently banned:.*" | sed 's/Currently banned://g')
-        TOTALBANS=$((TOTALBANS+BANS))
-
-        # Get Bantime for jail
-        BANTIME=$($SUDO "$FBIN" get "$JAIL" bantime)
-
-        # Assemble Output
-        OUTPUT="$OUTPUT\\nJail: $JAIL\\nBan Time: $BANTIME\\nCurrently Banned: $BANS\\nBanned IPs: $BANNED_IPS\\n"
+    # New bans in TIME_WINDOW
+    NEW_RAW=$(zgrep "Ban" /var/log/fail2ban.log | awk -v jail="$JAIL" -v mins="$TIME_WINDOW" '
+    BEGIN {count=0}
+    {
+        split($1,d,"-"); split($2,t,":");
+        ts=mktime(d[1]" "d[2]" "d[3]" "t[1]" "t[2]" "t[3])
+        if ($0 ~ jail && (systime() - ts <= mins*60)) count++
+    }
+    END {print count}')
+    NEW=$(echo "$NEW_RAW" | tr -cd '0-9')
+    NEW_BANS=$((NEW_BANS + NEW))
 done
 
-# Set default values
-if [ -z "$CRIT" ]; then
-        CRIT=20
-fi
+OUTPUT="fail2ban running | total_banned=${TOTALBANS};${WARN_TOTAL};${CRIT_TOTAL} new_bans_${TIME_WINDOW}min=${NEW_BANS};${WARN_HITS};${CRIT_HITS}"
 
-if [ -z "$WARN" ]; then
-        WARN=10
-fi
-
-if [ "$WARN" -ge "$CRIT" ]; then
-        print_error "Error: CRIT must be greater than WARN"
-fi
-
-# Append additional info
-OUTPUT=$(echo -e "$OUTPUT\\nTotal banned: $TOTALBANS IPs|banned_IP=${TOTALBANS};${WARN};${CRIT}")
-
-# States
-if [ "$TOTALBANS" -ge ${WARN} ] && [ "$TOTALBANS" -lt ${CRIT} ]; then
-        echo "WARNING:$OUTPUT"
-        exit 1
-elif [ "$TOTALBANS" -ge ${CRIT} ];then
-        echo "CRITICAL:$OUTPUT"
-        exit 2
+# Determine state
+if [ "$TOTALBANS" -ge "$CRIT_TOTAL" ] || [ "$NEW_BANS" -ge "$CRIT_HITS" ]; then
+    echo "CRITICAL: $OUTPUT"
+    exit 2
+elif [ "$TOTALBANS" -ge "$WARN_TOTAL" ] || [ "$NEW_BANS" -ge "$WARN_HITS" ]; then
+    echo "WARNING: $OUTPUT"
+    exit 1
 else
-        echo "$OUTPUT"
-        exit 0
+    echo "OK: $OUTPUT"
+    exit 0
 fi


### PR DESCRIPTION
- Added monitoring for new bans within a configurable time window (-m/-r/-R)
- Cleaned output for proper Icinga2 format
- Simplified per-jail display, removed IP list by default
- Retained total banned IPs monitoring with warning/critical thresholds
- Adjusted defaults to match site-specific values

Note: These changes have been made for personal use and on personal preference and as such may clash with the original creator's vision for the check, thus may be completely discarded