### PR TITLE
Add ability to set nagios user

### DIFF
--- a/check_fail2ban
+++ b/check_fail2ban
@@ -16,6 +16,7 @@
 # 240123 Version 1.05 - Fix output in jaillist (thanks to d-stevens)    #
 # 061223 Version 1.06 - Reduce number of sudo invocations               #
 #                                             (thanks to MarcSchmitzer) #
+# 190526 Version 1.07 - Ability to set nagios user                      #
 #########################################################################
 
 # Helper message
@@ -29,6 +30,7 @@ print_help() {
                                          -t Time: Display until when IPs will be banned
                                          -j <jaillist> i.e. comma separated string of jails, i.e. ssh,postfix
                                             Only check those jails
+                                         -u <username> defaults to nagios
                 Examples:
                         ./check_fail2ban -t -w 5 -c 10 -j ssh,postfix
                         ./check_fail2ban -t
@@ -52,18 +54,6 @@ if [ -z "$FBINSERVER" ]; then
 fi
 if [ -z "$SUDO" ]; then
         print_error "sudo not found. Please install it"
-fi
-
-# Check $SUDO permissions
-VISUDO=$($SUDO -l -U nagios)
-if echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} status$" &&
-   echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} status \*$" &&
-   echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} get \* bantime$"; then
-                :
-else
-                echo "Not all sudo permissions available! Please refer to documentation."
-                echo "If you have set them up, make sure that the command 'sudo -u nagios /usr/lib/nagios/plugins/check_fail2ban -t -w 1 -c 2' correctly displays your jails."
-                print_error "If they do not show up, try repairing sudo permissions with the command 'chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo'"
 fi
 
 
@@ -90,6 +80,10 @@ while test -n "$1"; do
             JAILLIST=$2
             shift
             ;;
+        -u)
+            NAGIOSUSER=$2
+            shift
+            ;;
         *)
             print_help
             print_error "Unknown argument: $1"
@@ -97,6 +91,23 @@ while test -n "$1"; do
     esac
   shift
 done
+
+# Check $NAGIOSUSER is set, and if not set default
+if [ -z "$NAGIOSUSER" ]; then
+        NAGIOSUSER="nagios"
+fi
+
+# Check $SUDO permissions
+VISUDO=$($SUDO -l -U ${NAGIOSUSER})
+if echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} status$" &&
+   echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} status \*$" &&
+   echo "$VISUDO" | grep -q "(root) NOPASSWD: ${FBIN} get \* bantime$"; then
+                :
+else
+                echo "Not all sudo permissions available! Please refer to documentation."
+                echo "If you have set them up, make sure that the command 'sudo -u ${NAGIOSUSER} /usr/lib/nagios/plugins/check_fail2ban -t -w 1 -c 2' correctly displays your jails."
+                print_error "If they do not show up, try repairing sudo permissions with the command 'chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo'"
+fi
 
 # Get List of Jails
 if [ ! "$MANUAL" = true ]; then


### PR DESCRIPTION
* Some systems might be running Nagios or NRPE under a different user, adding the `-u` argument allows for other users to pass the sudo check.